### PR TITLE
Deprecate this fork in favor the official one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,10 @@
 {
     "name": "rnijveld/xmlseclibs",
-    "description": "A PHP library for XML Security",
-    "authors": [
-        { "name": "Rob Richards" }
-    ],
-    "license": "BSD-3-Clause",
-    "type": "library",
-    "keywords": ["xml", "xmlsec", "security", "signing", "signature", "x.509", "certificate"],
-    "homepage": "http://code.google.com/p/xmlseclibs/",
-    "autoload": {
-        "files": ["xmlseclibs.php"]
+    "description": "Abandoned use robrichards/xmlseclibs",
+    "require": {
+        "robrichards/xmlseclibs": "~1.3"
     },
     "suggest": {
-        "ext/openssl": "",
-        "ext/mcrypt": ""
-    },
-    "time": "2013-06-19",
-    "replace": {
-        "cdatazone/xmlseclibs": "self.version",
-        "fr3d/xmlseclibs": "self.version",
-        "robrichards/xmlseclibs": "self.version"
+        "robrichards/xmlseclibs": "Official development repository"
     }
 }


### PR DESCRIPTION
Library is now been developed by the original author.

Please log into packagist.org and mark this package as abandoned in favor of robrichards/xmlseclibs
